### PR TITLE
Fix/#8 GitHub actions

### DIFF
--- a/.github/workflows/on_merge.yml
+++ b/.github/workflows/on_merge.yml
@@ -25,13 +25,12 @@ jobs:
       - name: build
         run: |
           yarn export
-      # 初回は1.0.0のままリリース
-      # - name: Update manifest.json
-      #   run: |
-      #     npx dot-json@1 extensions/manifest.json version ${{ steps.daily-version.outputs.version }}
+      - name: Update manifest.json
+        run: |
+          npx dot-json@1 extensions/manifest.json version ${{ steps.daily-version.outputs.version }}
       - name: Archive
         run: |
-          zip extension.zip ./extensions/**/*
+          zip -r extension.zip ./extensions
       - name: Submit
         run: |
           npx chrome-webstore-upload-cli@2 upload --source extension.zip --auto-publish
@@ -43,8 +42,7 @@ jobs:
       - name: Create release draft
         uses: softprops/action-gh-release@v1
         with:
-          # tag_name: ${{ steps.daily-version.outputs.version }}
-          tag_name: 1.0.1
+          tag_name: ${{ steps.daily-version.outputs.version }}
           draft: false
           generate_release_notes: true
           files: extension.zip

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,34 @@
+name: on_pull_request
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+jobs:
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+      - name: Prepare
+        run: |
+          yarn install
+          # yarn lint
+          # yarn test
+      - name: build
+        run: |
+          yarn export
+      - name: Update manifest.json
+        run: |
+          npx dot-json@1 extensions/manifest.json version ${{ steps.daily-version.outputs.version }}
+      - name: Archive
+        run: |
+          zip -r extension.zip ./extensions
+      - name: Check Archive
+        run: |
+          rm -rf ./extensions
+          unzip extension.zip
+          ls -lR ./extensions


### PR DESCRIPTION
## 関連Issus
close #8

## 変更点
- GitHub Actionsでのアーカイブ方法が間違っており、正しくファイルをバンドルできていなかったため修正。
- 加えてPRの際にARCHIVEが正しく行われているかを確認するworkflowを追加

## その他
- なし